### PR TITLE
Use ESA dependency and features-bom

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -22,6 +22,17 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>18.0.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>    
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -48,39 +59,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.1</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-            <version>1.0.10</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.1</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.json</artifactId>
-            <version>1.0.10</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>1.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>cdi-1.2</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -60,13 +60,13 @@
         </dependency>
         <dependency>
             <groupId>io.openliberty.features</groupId>
-            <artifactId>jaxrs-2.1</artifactId>
+            <artifactId>jaxrs-2.0</artifactId>
             <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.openliberty.features</groupId>
-            <artifactId>jsonp-1.1</artifactId>
+            <artifactId>jsonp-1.0</artifactId>
             <type>esa</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -32,7 +32,8 @@
                 <scope>import</scope>
             </dependency>
         </dependencies>
-    </dependencyManagement>    
+    </dependencyManagement>  
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -80,21 +81,25 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -131,11 +131,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
                 <configuration>
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-runtime</artifactId>
+                        <artifactId>openliberty-kernel</artifactId>
                         <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
@@ -148,6 +148,18 @@
                     </bootstrapProperties>
                 </configuration>
                 <executions>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>install-liberty</id>
                         <phase>prepare-package</phase>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.2</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -149,6 +149,13 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>install-liberty</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-server</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>install-feature</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -159,13 +166,6 @@
                                 <acceptLicense>true</acceptLicense>
                             </features>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>install-liberty</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>install-server</goal>
-                        </goals>
                     </execution>
                     <execution>
                         <id>install-app</id>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.2</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -22,6 +22,17 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>18.0.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -48,39 +59,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-            <version>1.0.10</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.json</artifactId>
-            <version>1.0.10</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>1.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>cdi-1.2</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -80,21 +80,25 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -131,11 +131,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
                 <configuration>
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-runtime</artifactId>
+                        <artifactId>openliberty-kernel</artifactId>
                         <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
@@ -148,6 +148,18 @@
                     </bootstrapProperties>
                 </configuration>
                 <executions>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>install-liberty</id>
                         <phase>prepare-package</phase>


### PR DESCRIPTION
This pull request updates the project pom.xml file to replace all the dependencies with imported scope with the esa feature dependencies, and provides an alternative to use openliberty-kernel runtime with only the required features installed from the esa feature dependencies using the Liberty Maven plugin install-feature goal.

The esa feature dependency will automatically pull the feature's spec api, server api/spi dependencies for building the project.